### PR TITLE
Option to disable language detection

### DIFF
--- a/src/common/services/user-options.js
+++ b/src/common/services/user-options.js
@@ -5,7 +5,8 @@ const storageKey = 'userOptions';
 const defaultOptions = {
   targetLanguage: 'en',
   sourceLanguage: '',
-  ttsEnabled: false
+  ttsEnabled: false,
+  autoDetectLanguage: true
 };
 
 export default class UserOptions {

--- a/src/content/components/Main/Main.jsx
+++ b/src/content/components/Main/Main.jsx
@@ -29,7 +29,7 @@ export default class Main extends PureComponent {
   }
 
   componentDidMount() {
-    lookup(this.props.word, options.targetLanguage, options.sourceLanguage)
+    lookup(this.props.word, options.targetLanguage, options.sourceLanguage, options.autoDetectLanguage)
       .then(data => this._onLoad(data))
       .catch(() => this._onLoad());
   }

--- a/src/content/services/lookup.js
+++ b/src/content/services/lookup.js
@@ -8,7 +8,7 @@ function load(word, lang, targetLang) {
     .then(data => ({ lang: lang, data: data }));
 }
 
-export default function lookup(word, targetLang, sourceLang) {
-  const lang = detectLanguage() || sourceLang || 'en';
+export default function lookup(word, targetLang, sourceLang, autoDetectLang) {
+  const lang = autoDetectLang ? detectLanguage() || sourceLang || 'en' : sourceLang || 'en';
   return load(word, lang, targetLang);
 }

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -115,6 +115,13 @@
       </p>
 
       <p>
+        <label>
+          <input name="autoDetectLanguage" type="checkbox" checked />
+          Enable automatic website language detection
+        </label>
+      </p>
+
+      <p>
         <button type="submit">Save</button>
         <span id="status"></span>
       </p>

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -4,7 +4,8 @@ import userOptions from '../common/services/user-options';
 function saveOptions(form) {
   const data = {
     targetLanguage: form.elements.targetLanguage.value,
-    sourceLanguage: form.elements.sourceLanguage.value
+    sourceLanguage: form.elements.sourceLanguage.value,
+    autoDetectLanguage: form.elements.autoDetectLanguage.checked
   };
 
   userOptions.set(data).then(() => {
@@ -23,6 +24,7 @@ function restoreOptions(form) {
   userOptions.get().then(options => {
     form.elements.targetLanguage.value = options.targetLanguage;
     form.elements.sourceLanguage.value = options.sourceLanguage;
+    form.elements.autoDetectLanguage.checked = options.autoDetectLanguage;
   });
 }
 


### PR DESCRIPTION
Hi, I noticed a somewhat problematic behaviour with the detectLanguage function and I tried to fix it. I'm not really familiar with the codebase, so I'm open to any suggestions on how to deal with this problem.

### The problem

On websites with incorrect language attribute, the detectLanguage function is not always preferred. For example, a website I use to learn German uses 'en' as the language attribute, so it tries to fetch English definitions instead of German and fails.

### My solution

I added an option 'autoDetectLanguage' that enables/disables the detectLanguage function. It's set to true by default, so that things don't change for people who are already using the extension this way (maybe it should be false by default, that means renaming the option to something like forceUserSourceLang). After setting to false, it uses the user language setting instead of detecting the language from the document.